### PR TITLE
fix(response_agent): correct tool call filtering and add validation

### DIFF
--- a/src/response_agent.py
+++ b/src/response_agent.py
@@ -192,10 +192,13 @@ Reply "TERMINATE" in the end when everything is done."""
     # Grab everything but tool calls
     results_to_summarize = [
         [
-            x for x in this_result.chat_history if 'tool' not in str(x)
+            x for x in this_result.chat_history if 'tool_call' not in str(x)
         ]
         for this_result in chat_results
     ]
+
+    if any([len(x) == 0 for x in results_to_summarize]):
+        raise ValueError("Something went wrong with collecting results to summarize")
 
     summary_results = summary_assistant.initiate_chats(
         [
@@ -277,7 +280,9 @@ def process_repository(
 
 if __name__ == '__main__':
     # Example usage
-    repo_name = "katzlabbrandeis/blech_clust"
+    # repo_name = "katzlabbrandeis/blech_clust"
+    tracked_repos = bot_tools.get_tracked_repos()
+    repo_name = tracked_repos[1]
     # process_repository(repo_name)
     client = get_github_client()
     repo = get_repository(client, repo_name)

--- a/src/response_agent.py
+++ b/src/response_agent.py
@@ -198,7 +198,8 @@ Reply "TERMINATE" in the end when everything is done."""
     ]
 
     if any([len(x) == 0 for x in results_to_summarize]):
-        raise ValueError("Something went wrong with collecting results to summarize")
+        raise ValueError(
+            "Something went wrong with collecting results to summarize")
 
     summary_results = summary_assistant.initiate_chats(
         [


### PR DESCRIPTION
- Changed the filter check from 'tool' to 'tool_call' in chat history evaluation.
- Added a validation step to raise a ValueError if any of the result summaries are empty, ensuring data integrity before processing.