### PR TITLE
fix(bot_tools): remove unnecessary line breaks in string concatenation

### DIFF
--- a/src/bot_tools.py
+++ b/src/bot_tools.py
@@ -263,7 +263,7 @@ def readfile(filepath: str, token_threshold: int = 100_000) -> str:
     numbered_lines = [f"{i:04}: {line}" for i, line in enumerate(data)]
 
     # Check total tokens
-    full_content = "\n".join(numbered_lines)
+    full_content = "".join(numbered_lines)
     total_tokens = estimate_tokens(full_content)
 
     if total_tokens <= token_threshold:
@@ -286,7 +286,7 @@ def readfile(filepath: str, token_threshold: int = 100_000) -> str:
                f"Use readlines({filepath}, start_line, end_line) "
                f"to read specific ranges.")
 
-    data = "\n".join(included_lines)
+    data = "".join(included_lines)
     data += f"\n\n{warning}"
 
     return data
@@ -343,7 +343,7 @@ def readlines(
                f"Use readlines({filepath}, start_line, end_line) "
                f"to read specific ranges.")
 
-    data = "\n".join(included_lines)
+    data = "".join(included_lines)
     data += f"\n\n{warning}"
 
     return data


### PR DESCRIPTION
- Replaced instances of `"\n".join(lines)` with `"".join(lines)` to prevent adding extra line breaks when concatenating strings.
- Adjusted string handling in `readfile` and `readlines` functions to improve consistency and accuracy of the computed content.