### PR TITLE
feat(setup) : Use makefile to install aider separately

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U setuptools wheel
-        pip install -r requirements.txt
+        make install-deps
 
     - name: Run tests with coverage
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,7 @@
 name: Run Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        make install-deps
+        make install
 
     - name: Run tests with coverage
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+.PHONY: all install install-deps install-aider test clean
+
+all: install
+
+install: install-deps install-aider
+
+install-deps:
+	@echo "Installing Python dependencies..."
+	python -m pip install -r requirements.txt
+
+install-aider:
+	@echo "Installing aider..."
+	python -m pip install aider-install
+	aider-install
+
+test:
+	@echo "Running tests..."
+	pytest
+
+clean:
+	@echo "Cleaning up..."
+	find . -type d -name __pycache__ -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+	find . -type f -name "*.pyo" -delete
+	find . -type f -name "*.pyd" -delete
+	find . -type d -name "*.egg-info" -exec rm -rf {} +
+	find . -type d -name "*.egg" -exec rm -rf {} +
+	find . -type d -name ".pytest_cache" -exec rm -rf {} +
+	find . -type d -name ".coverage" -exec rm -rf {} +
+	find . -type d -name "htmlcov" -exec rm -rf {} +
+	find . -type d -name "dist" -exec rm -rf {} +
+	find . -type d -name "build" -exec rm -rf {} +
+
+help:
+	@echo "Available targets:"
+	@echo "  all          : Install dependencies and aider (default)"
+	@echo "  install      : Install dependencies and aider"
+	@echo "  install-deps : Install Python dependencies from requirements.txt"
+	@echo "  install-aider: Install aider tool"
+	@echo "  test         : Run tests with pytest"
+	@echo "  clean        : Remove Python cache files and build artifacts"
+	@echo "  help         : Show this help message"

--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ source venv/bin/activate  # On Linux/Mac
 .\venv\Scripts\activate  # On Windows
 ```
 
-3. Install dependencies:
+3. Install dependencies and tools:
 ```bash
-pip install -r requirements.txt
+# Install all dependencies and aider
+make install
+
+# Or install components separately
+make install-deps  # Just Python dependencies
+make install-aider # Just aider tool
 ```
 
 4. Create a `.env` file with your API tokens:

--- a/aider_install.sh
+++ b/aider_install.sh
@@ -1,2 +1,0 @@
-python -m pip install aider-install
-aider-install

--- a/aider_install.sh
+++ b/aider_install.sh
@@ -1,0 +1,2 @@
+python -m pip install aider-install
+aider-install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy
 PyGithub>=1.55
 python-dotenv>=0.19.0
 requests>=2.26.0
@@ -7,7 +6,6 @@ pyautogen>=0.2.0
 pre-commit>=3.5.0
 urlextract>=1.0.0
 beautifulsoup4>=4.9.3
-aider-chat
 gitpython
 pytest
 pytest-cov

--- a/run_response_agent.sh
+++ b/run_response_agent.sh
@@ -13,19 +13,20 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 # Navigate to the script directory
-cd "$(dirname "$0")"
-echo "Directory: $(pwd)"
+# cd "$(dirname "$0")"
+# echo "Directory: $(pwd)"
 
 # Activate virtual environment if it exists
-if [ -f "../venv/bin/activate" ]; then
-    source ../venv/bin/activate
-    echo "Virtual environment activated from" $(realpath ../venv/bin/activate)
+VENV_ACTIVATE_PATH=$(realpath ./venv/bin/activate)
+if [ -f "$VENV_ACTIVATE_PATH" ]; then
+    source $VENV_ACTIVATE_PATH
+    echo "Virtual environment activated from" $VENV_ACTIVATE_PATH
 fi
 
 # Run the response_agent.py script in a loop with the specified delay
 echo "Running response_agent.py with delay of $DELAY seconds"
 while true; do
-    python3 response_agent.py
+    python3 src/response_agent.py
     echo "Next run in $DELAY seconds"
     sleep "$DELAY"  # Wait for the specified delay before running again
 done

--- a/src/triggers.py
+++ b/src/triggers.py
@@ -1,11 +1,11 @@
 """
 Functions to check specific conditions
 """
+import os  # noqa: E501
+import sys  # noqa: E501
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))  # noqa: E501
 from github import Issue
 from src.git_utils import get_issue_comments, has_linked_pr, get_linked_pr
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
 def has_blech_bot_tag(issue: Issue) -> bool:

--- a/src/triggers.py
+++ b/src/triggers.py
@@ -3,6 +3,9 @@ Functions to check specific conditions
 """
 from github import Issue
 from src.git_utils import get_issue_comments, has_linked_pr, get_linked_pr
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 
 def has_blech_bot_tag(issue: Issue) -> bool:

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,9 +1,9 @@
 import sys  # noqa
 import os  # noqa
 
-# Add the src directory to the path so we can import the modules
-sys.path.insert(0, os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..')))  # noqa
+# # Add the src directory to the path so we can import the modules
+# sys.path.insert(0, os.path.abspath(
+#     os.path.join(os.path.dirname(__file__), '..')))  # noqa
 
 from src.triggers import (
     has_blech_bot_tag,


### PR DESCRIPTION
feat(setup): simplify installation process with aider-install script

- Added `aider_install.sh` for streamlined installation using `aider-install`.
- Removed `aider-chat` and `numpy` from `requirements.txt` as they are no longer necessary.

build: add Makefile for project installation and management

Move commands from aider_intall to Makefile

chore: update workflow to use makefile for dependency installation

fix(ci): correct make command for installing dependencies

- Changed `make install-deps` to `make install` in the GitHub Actions workflow to properly install dependencies before running tests.